### PR TITLE
Bump glider-js version to 1.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     ]
   },
   "dependencies": {
-    "glider-js": "1.6.3"
+    "glider-js": "1.6.6"
   },
   "storybook-deployer": {
     "gitUsername": "hipstersmoothie",


### PR DESCRIPTION
Version `1.6.3` have issue with global window override which can make issues on SSR