### PR TITLE
fix: Destroy glider on unmount

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -219,6 +219,10 @@ export default class GliderComponent extends React.Component<IGliderProps> {
     removeEventListener('glider-add', this.props.onAdd);
     removeEventListener('glider-destroy', this.props.onDestroy);
     removeEventListener('glider-slide-hidden', this.props.onSlideHidden);
+
+    if (this.glider) {
+      this.glider.destroy();
+    }
   }
 
   private positionGlider() {


### PR DESCRIPTION
Hi! I have an error in my app after ReactGlider is destroyed when I try to resize window:

```
glider.js:216 Uncaught TypeError: Cannot read property '_func' of null
    at glider.js:216
    at Array.forEach (<anonymous>)
    at _window.Glider.gliderPrototype.bindArrows (glider.js:212)
    at _window.Glider.gliderPrototype.init (glider.js:141)
```

After unmounting glider continues listenining to window.resize event.  To prevent this we need to call destroy() on componentWillUnmount()