### PR TITLE
fix(responsive-glider): allow for undefined breakpoint settings

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,8 +8,8 @@ export interface BreakPoint {
   settings: {
     slidesToShow: number | 'auto';
     slidesToScroll: number | 'auto';
-    itemWidth: number;
-    duration: number;
+    itemWidth?: number;
+    duration?: number;
   };
 }
 


### PR DESCRIPTION
Fix for https://github.com/hipstersmoothie/react-glider/issues/39
To allow for continued use of undefined `itemWidth` and `duration`