### PR TITLE
Update scrollItem() typing

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -173,7 +173,7 @@ export interface GliderMethods {
   refresh(rebuildPaging?: boolean): void;
   setOption(options: GliderOptions, global?: boolean): void;
   scrollTo(pixelOffset: number): void;
-  scrollItem(slideIndex: number, isActuallyDotIndex?: boolean): void;
+  scrollItem(slideIndex: string | number, isActuallyDotIndex?: boolean): void;
 }
 
 const GliderComponent = React.forwardRef(


### PR DESCRIPTION
## What's Changing

- Change scrollItem()'s slideIndex type to "string | number" to support string parameters (prev, next). This will match with [glider-js](https://nickpiscitelli.github.io/Glider.js/)'s definition.
- Fixes #45.

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [x] `minor`
- [ ] `major`
