### PR TITLE
fix: change type for rewind prop to boolean

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -57,7 +57,7 @@ export interface GliderProps {
   /**
    * If true, Glider.js will scroll to the beginning/end when its respective endpoint is reached
    */
-  rewind?: number;
+  rewind?: boolean;
   /**
    * An aggravator used to control animation speed. Higher is slower!
    *


### PR DESCRIPTION
The rewind prop is defined as `number` however the glider docs state its a `boolean`