### PR TITLE
Adding support for elements as arrows

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -67,8 +67,8 @@ export interface GliderProps {
   dots?: string;
   /** An object containing the prev/next arrows selectors */
   arrows?: {
-    prev: string;
-    next: string;
+    prev: string | JSX.Element;
+    next: string | JSX.Element;
   };
 
   /**
@@ -180,6 +180,19 @@ export interface GliderMethods {
   scrollTo(pixelOffset: number): void;
   scrollItem(slideIndex: string | number, isActuallyDotIndex?: boolean): void;
 }
+
+
+export const useElement = (): [JSX.Element | undefined, (node: any) => void] => {
+  const [element, setElement] = React.useState<JSX.Element | undefined>(undefined);
+
+  const ref = React.useCallback((node) => {
+    if (node !== null) {
+      setElement(node);
+    }
+  }, []);
+
+  return [element, ref];
+};
 
 const GliderComponent = React.forwardRef(
   (props: GliderProps, ref: React.Ref<GliderMethods>) => {

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -3,7 +3,7 @@ import { storiesOf, DecoratorFn } from '@storybook/react';
 import { withKnobs, number, boolean } from '@storybook/addon-knobs';
 
 import '../glider.defaults.css';
-import Glider, { GliderMethods } from '../src';
+import Glider, { GliderMethods, useElement } from '../src';
 
 const styles = {
   width: '80%',
@@ -361,4 +361,61 @@ storiesOf('Glider', module)
         </button>
       </div>
     </>
-  ));
+  )).add('Custom Element Arrows', () => {
+
+    const [leftElement, leftArrowRef] = useElement()
+    const [rightElement, rightArrowRef] = useElement()
+
+    return (
+      <>
+        <Glider
+          draggable
+          hasArrows
+          hasDots
+          slidesToShow={2}
+          className="gradient-outline"
+        >
+          <Pane>1</Pane>
+          <Pane>2</Pane>
+          <Pane>3</Pane>
+          <Pane>4</Pane>
+          <Pane>5</Pane>
+          <Pane>6</Pane>
+        </Glider>
+        <Glider
+          draggable
+          hasArrows
+          hasDots
+          slidesToShow={1}
+          className="gradient-outline"
+          arrows={{
+            prev: leftElement,
+            next: rightElement,
+          }}
+        >
+          <Pane>1</Pane>
+          <Pane>2</Pane>
+          <Pane>3</Pane>
+          <Pane>4</Pane>
+        </Glider>
+        <div style={{ position: 'relative' }}>
+          <button
+            ref={leftArrowRef}
+            type="button"
+            className="glider-prev"
+            aria-label="Previous"
+          >
+            PREVIOUS
+          </button>
+          <button
+            ref={rightArrowRef}
+            type="button"
+            className="glider-next"
+            aria-label="Next"
+          >
+            NEXT
+          </button>
+        </div>
+      </>  
+    )
+  })


### PR DESCRIPTION
## What's Changing
Closes #36
Adding support for allowing custom arrows to use elements instead of only strings.

There are other ways of implementing this change for example: 
- Allowing the user to pass the ref directly instead of having to use the `useElement` hook, but those require a larger refactor of the code and could be potentially breaking for some users.
## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

