### PR TITLE
Updated CircleCI to use LTS node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/react-glider
   docker:
-    - image: circleci/node:latest-browsers
+    - image: cimg/node:lts
 
 jobs:
   install:


### PR DESCRIPTION
## What's Changing

Updated CircleCI to use LTS node version

## Change Type
- [x] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
