### PR TITLE
Replaced useLayoutEffect with useEffect

### DIFF
--- a/glider.defaults.css
+++ b/glider.defaults.css
@@ -15,19 +15,24 @@
 .glider {
   height: 300px;
 }
+
 .glider-contain {
   margin-bottom: 25px;
 }
+
 .glider-dots {
   margin-top: 15px;
 }
+
 .glider-track {
   height: 100%;
 }
+
 .gradient-outline {
   border: 3px solid !important;
   border-image: linear-gradient(to right, #8cc9f0, #efa8b0, #a89cc8) 5 !important;
 }
+
 .glider-slide {
   background: white;
   display: flex;
@@ -35,13 +40,16 @@
   align-items: center;
   border: 1px solid #f5f5f5;
 }
+
 .glider-slide h1 {
   color: #8cc9f0;
   font-weight: bold;
 }
-.glider-slide:nth-child(2n) h1 {
+
+.glider-slide:nth-child(3n - 1) h1 {
   color: #a89cc8;
 }
+
 .glider-slide:nth-child(3n) h1 {
   color: #efa8b0;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -168,7 +168,6 @@ type GliderOptions = Pick<
   | 'draggable'
   | 'dragVelocity'
   | 'duration'
-  | 'skipTrack'
 >;
 
 export interface GliderMethods {
@@ -243,7 +242,7 @@ const GliderComponent = React.forwardRef(
     );
 
     // initialize the glider
-    React.useLayoutEffect(() => {
+    React.useEffect(() => {
       const { current } = innerRef;
 
       if (current && isReady) {
@@ -373,7 +372,7 @@ const GliderComponent = React.forwardRef(
           </button>
         )}
 
-        <div id={autoId} className={className} ref={innerRef}>
+        <div id={autoId} className={`glider ${className}`} ref={innerRef}>
           {children}
         </div>
 

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -57,11 +57,14 @@ storiesOf('Glider', module)
       itemWidth={number('itemWidth', 0)}
       duration={number('duration', 0.5)}
       className="gradient-outline"
+      skipTrack
     >
-      <Pane style={{ height: 'auto', width: 756 }}>1</Pane>
-      <Pane style={{ height: 'auto', width: 756 }}>2</Pane>
-      <Pane style={{ height: 'auto', width: 756 }}>3</Pane>
-      <Pane style={{ height: 'auto', width: 756 }}>4</Pane>
+      <div className="glider-track">
+        <Pane style={{ minWidth: '100%' }}>1</Pane>
+        <Pane style={{ minWidth: '100%' }}>2</Pane>
+        <Pane style={{ minWidth: '100%' }}>3</Pane>
+        <Pane style={{ minWidth: '100%' }}>4</Pane>
+      </div>
     </Glider>
   ))
   .add('Single Item', () => (
@@ -72,19 +75,22 @@ storiesOf('Glider', module)
       hasDots
       slidesToShow={1}
       className="gradient-outline"
+      skipTrack
     >
-      <Pane>1</Pane>
-      <Pane>2</Pane>
-      <Pane>3</Pane>
-      <Pane>4</Pane>
-      <Pane>5</Pane>
-      <Pane>6</Pane>
-      <Pane>7</Pane>
-      <Pane>8</Pane>
-      <Pane>9</Pane>
-      <Pane>10</Pane>
-      <Pane>11</Pane>
-      <Pane>12</Pane>
+      <div className="glider-track">
+        <Pane>1</Pane>
+        <Pane>2</Pane>
+        <Pane>3</Pane>
+        <Pane>4</Pane>
+        <Pane>5</Pane>
+        <Pane>6</Pane>
+        <Pane>7</Pane>
+        <Pane>8</Pane>
+        <Pane>9</Pane>
+        <Pane>10</Pane>
+        <Pane>11</Pane>
+        <Pane>12</Pane>
+      </div>
     </Glider>
   ))
   .add('Multiple Item', () => (


### PR DESCRIPTION
## What's Changing

Replaced `useLayoutEffect` with `useEffect` to remove server-side warning as document in #111. This would enable you to render the Glider on the server-side and then progressively enhance it once the client-side scripts are available.

`useLayoutEffect` is synchronous and blocks visual updates, so following the change to `useEffect`, the Glider is initialized _after_ content is painted to the screen.

Dependent on https://github.com/NickPiscitelli/Glider.js/pull/235

## Change Type

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [x] `major`

**Marked as a major change since users may see a sudden increase in layout shift as the Glider is initialized later.**